### PR TITLE
fix: removed section on poetry

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,25 +25,8 @@ Jordan Cairns, Sid Grover, Scout McKee
 The following code should be ran to install the package: 
 ```bash
 pip install datexplore
-cd datexplore
-```
-To install poetry:
-``` bash
-#Install poetry
-pip install poetry
-poetry install
-```
-To run the tests run: 
-``` bash
-pytest tests/*
 ```
 
-To get coverage report:
-```bash
-pytest --cov=datexplore --cov-report html tests/
-cd htmlcov
-open index.html
-```
 ## 📖 Outline
 
 Datexplore is a python package for the early stages of a data analysis project. It contains tools helpful for exploratory data analysis and data cleaning. The aim of this package is to help with some common tasks involved in these early stages of projects. The package includes tools for common EDA visualizations, data cleaning procedures, and detecting outlier numerical data.


### PR DESCRIPTION
poetry and pytest etc are no longer required since the package is now hosted on PyPI and tests run with continuous integration